### PR TITLE
Feature/#10 - hide APIKEY

### DIFF
--- a/NBCAMP-movie-team1/NBCAMP-movie-team1.xcodeproj/project.pbxproj
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		1B037D312B54FA23009323C4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1B037D2F2B54FA23009323C4 /* LaunchScreen.storyboard */; };
 		1B037D442B551D40009323C4 /* MovieAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B037D432B551D40009323C4 /* MovieAPI.swift */; };
 		1B037D462B552082009323C4 /* MovieAPIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B037D452B552082009323C4 /* MovieAPIModel.swift */; };
+		1B037D4B2B56122B009323C4 /* MovieInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1B037D4A2B56122B009323C4 /* MovieInfo.plist */; };
+		1B037D4E2B5612B8009323C4 /* NBCAMPMovieTeam1++Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B037D4D2B5612B8009323C4 /* NBCAMPMovieTeam1++Bundle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,7 +28,8 @@
 		1B037D322B54FA23009323C4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1B037D432B551D40009323C4 /* MovieAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieAPI.swift; sourceTree = "<group>"; };
 		1B037D452B552082009323C4 /* MovieAPIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieAPIModel.swift; sourceTree = "<group>"; };
-		1B037D492B5548C3009323C4 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
+		1B037D4A2B56122B009323C4 /* MovieInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = MovieInfo.plist; sourceTree = "<group>"; };
+		1B037D4D2B5612B8009323C4 /* NBCAMPMovieTeam1++Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NBCAMPMovieTeam1++Bundle.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -43,7 +46,6 @@
 		1B037D182B54FA22009323C4 = {
 			isa = PBXGroup;
 			children = (
-				1B037D492B5548C3009323C4 /* Secrets.xcconfig */,
 				1B037D232B54FA22009323C4 /* NBCAMP-movie-team1 */,
 				1B037D222B54FA22009323C4 /* Products */,
 			);
@@ -63,6 +65,7 @@
 				1B037D382B54FA27009323C4 /* Global */,
 				1B037D3B2B54FA3F009323C4 /* Presentation */,
 				1B037D322B54FA23009323C4 /* Info.plist */,
+				1B037D4A2B56122B009323C4 /* MovieInfo.plist */,
 			);
 			path = "NBCAMP-movie-team1";
 			sourceTree = "<group>";
@@ -79,6 +82,7 @@
 		1B037D392B54FA2E009323C4 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				1B037D4D2B5612B8009323C4 /* NBCAMPMovieTeam1++Bundle.swift */,
 				1B037D242B54FA22009323C4 /* AppDelegate.swift */,
 				1B037D262B54FA22009323C4 /* SceneDelegate.swift */,
 			);
@@ -203,6 +207,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1B037D312B54FA23009323C4 /* LaunchScreen.storyboard in Resources */,
+				1B037D4B2B56122B009323C4 /* MovieInfo.plist in Resources */,
 				1B037D2E2B54FA23009323C4 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -216,6 +221,7 @@
 			files = (
 				1B037D292B54FA22009323C4 /* MainViewController.swift in Sources */,
 				1B037D442B551D40009323C4 /* MovieAPI.swift in Sources */,
+				1B037D4E2B5612B8009323C4 /* NBCAMPMovieTeam1++Bundle.swift in Sources */,
 				1B037D462B552082009323C4 /* MovieAPIModel.swift in Sources */,
 				1B037D252B54FA22009323C4 /* AppDelegate.swift in Sources */,
 				1B037D272B54FA22009323C4 /* SceneDelegate.swift in Sources */,
@@ -238,7 +244,6 @@
 /* Begin XCBuildConfiguration section */
 		1B037D332B54FA23009323C4 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1B037D492B5548C3009323C4 /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -302,7 +307,6 @@
 		};
 		1B037D342B54FA23009323C4 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1B037D492B5548C3009323C4 /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -359,7 +363,6 @@
 		};
 		1B037D362B54FA23009323C4 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1B037D492B5548C3009323C4 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -387,7 +390,6 @@
 		};
 		1B037D372B54FA23009323C4 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1B037D492B5548C3009323C4 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Global/App/NBCAMPMovieTeam1++Bundle.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Global/App/NBCAMPMovieTeam1++Bundle.swift
@@ -1,0 +1,19 @@
+//
+//  NBCAMPMovieTeam1++Bundle.swift
+//  NBCAMP-movie-team1
+//
+//  Created by t2023-m0035 on 1/16/24.
+//
+
+import Foundation
+
+extension Bundle {
+    var apiKey: String {
+        guard let file = self.path(forResource: "MovieInfo", ofType: "plist") else { return "" }
+        
+        guard let resource = NSDictionary(contentsOfFile: file) else { return "" }
+        guard let key = resource["API_KEY"] as? String else { fatalError("MovieInfo requires API_KEY configuration.") }
+        
+        return key
+    }
+}

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Info.plist
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>API_KEY</key>
-	<string>$(API_KEY)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/MovieInfo.plist
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/MovieInfo.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>Please enter your APIKEY</string>
+</dict>
+</plist>

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/Networking/MovieAPI.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/Networking/MovieAPI.swift
@@ -10,12 +10,14 @@ import Foundation
 final class MovieRequest {
     
     static func makeMovieRequest(completion: @escaping (Result<[Movie], Error>) -> Void) {
+        let apiKey = Bundle.main.apiKey
+        
         let url = URL(string: "https://api.themoviedb.org/3/movie/upcoming?language=en-US&page=1")!
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.allHTTPHeaderFields = [
             "accept": "application/json",
-            "Authorization": Bundle.main.infoDictionary?["API_KEY"] as! String
+            "Authorization": "Bearer \(apiKey)"
         ]
         
         let task = URLSession.shared.dataTask(with: request) { (data, response, error) in


### PR DESCRIPTION
- APIKEY를 숨기기 위해 plist 사용
- 기존의 xcconfig + git ignore 는 설정상 오류와 휴먼에러 발생 가능성이 높기 때문에 plist 로 변경함
- APIKEY를 담아둘 MovieInfo.plist는 추적 중지 해둠
`git update-index --skip-worktree  NBCAMP-movie-team1/NBCAMP-movie-team1/MovieInfo.plist`
 [ 관련된 내용 블로그 링크](https://nareunhagae.tistory.com/44)

