### PR TITLE
Feature/#19 movie detail page data , Feature/#22 navigation search button

### DIFF
--- a/NBCAMP-movie-team1/NBCAMP-movie-team1.xcodeproj/project.pbxproj
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1.xcodeproj/project.pbxproj
@@ -550,7 +550,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.7;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -577,7 +577,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.7;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1.xcodeproj/project.pbxproj
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		1B037D8A2B580176009323C4 /* CustomCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B037D892B580176009323C4 /* CustomCollectionView.swift */; };
 		1B037D8C2B58362E009323C4 /* MovieListManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B037D8B2B58362E009323C4 /* MovieListManager.swift */; };
 		1B037D8F2B5847E7009323C4 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B037D8E2B5847E7009323C4 /* ImageLoader.swift */; };
+		1B037D912B58CBDB009323C4 /* DetailMovieManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B037D902B58CBDB009323C4 /* DetailMovieManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -68,6 +69,7 @@
 		1B037D892B580176009323C4 /* CustomCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCollectionView.swift; sourceTree = "<group>"; };
 		1B037D8B2B58362E009323C4 /* MovieListManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieListManager.swift; sourceTree = "<group>"; };
 		1B037D8E2B5847E7009323C4 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
+		1B037D902B58CBDB009323C4 /* DetailMovieManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailMovieManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -203,6 +205,7 @@
 		1B037D532B5664BB009323C4 /* DetailMovie */ = {
 			isa = PBXGroup;
 			children = (
+				1B037D902B58CBDB009323C4 /* DetailMovieManager.swift */,
 				1B037D542B5664CC009323C4 /* DetailMovieViewController.swift */,
 			);
 			path = DetailMovie;
@@ -383,6 +386,7 @@
 				1B037D612B576A91009323C4 /* MovieListViewController.swift in Sources */,
 				1B037D292B54FA22009323C4 /* MainViewController.swift in Sources */,
 				1B037D6C2B5771D2009323C4 /* MovieListCollectionView.swift in Sources */,
+				1B037D912B58CBDB009323C4 /* DetailMovieManager.swift in Sources */,
 				1B037D7A2B57BBBF009323C4 /* MovieListCollectionViewCell.swift in Sources */,
 				1B037D8F2B5847E7009323C4 /* ImageLoader.swift in Sources */,
 				1B037D5B2B567B8D009323C4 /* PointButton.swift in Sources */,

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/Model/DetailMovieAPIModel.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/Model/DetailMovieAPIModel.swift
@@ -7,88 +7,18 @@
 
 import Foundation
 
-struct DetailMovie: Decodable {
-    let adult: Bool
-    let backdropPath: String?
-    let belongsToCollection: BelongsToCollection?
-    let budget: Int
-    let genres: [Genre]
-    let homepage: String?
+struct MovieInfo: Decodable {
     let id: Int
-    let imdbId: String?
-    let originalLanguage: String?
-    let originalTitle: String?
-    let overview: String
-    let popularity: Double
-    let posterPath: String?
-    let productionCompanies: [ProductionCompany]?
-    let productionCountries: [ProductionCountry]?
-    let releaseDate: String?
-    let revenue: Int
-    let runtime: Int
-    let spokenLanguages: [SpokenLanguage]?
-    let status: String
-    let tagline: String?
     let title: String
-    let video: Bool
-    let voteAverage: Double?
-    let voteCount: Int?
-    
-    private enum CodingKeys: String, CodingKey {
-        case adult
-        case backdropPath = "backdrop_path"
-        case belongsToCollection = "belongs_to_collection"
-        case budget
-        case genres
-        case homepage
-        case id
-        case imdbId = "imdb_id"
-        case originalLanguage = "original_language"
-        case originalTitle = "original_title"
-        case overview
-        case popularity
-        case posterPath = "poster_path"
-        case productionCompanies = "production_companies"
-        case productionCountries = "production_countries"
-        case releaseDate = "release_date"
-        case revenue
-        case runtime
-        case spokenLanguages = "spoken_languages"
-        case status
-        case tagline
-        case title
-        case video
-        case voteAverage = "vote_average"
-        case voteCount = "vote_count"
-    }
-}
-
-struct BelongsToCollection: Decodable {
-    let id: Int
-    let name: String
     let posterPath: String?
-    let backdropPath: String?
-}
+    let releaseDate: String
+    let overview: String
 
-struct Genre: Decodable {
-    let id: Int
-    let name: String
-}
-
-struct ProductionCompany: Decodable {
-    let id: Int
-    let logoPath: String?
-    let name: String
-    let originCountry: String
-}
-
-struct ProductionCountry: Decodable {
-    let iso31661: String
-    let name: String
-}
-
-struct SpokenLanguage: Decodable {
-    let englishName: String
-    let iso6391: String
-    let name: String
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case posterPath = "poster_path"
+        case releaseDate = "release_date"
+        case overview
+    }
 }

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/Networking/DetailMovieAPI.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/Networking/DetailMovieAPI.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 final class DetailMovieRequest {
-    static func detailMovieRequest(_ movieId: Int, completion: @escaping (Result<DetailMovie, Error>) -> Void) {
+    static func detailMovieRequest(_ movieId: Int, completion: @escaping (Result<MovieInfo, Error>) -> Void) {
         let apiKey = Bundle.main.apiKey
         
         let url = URL(string: "https://api.themoviedb.org/3/movie/\(movieId)?language=en-US")!
@@ -23,15 +23,13 @@ final class DetailMovieRequest {
             if let error = error {
                 completion(.failure(error))
                 return
-            }else if let httpResponse = response as? HTTPURLResponse {
+            } else if let httpResponse = response as? HTTPURLResponse {
                 print("Status Code: \(httpResponse.statusCode)")
                 
                 if let data = data {
                     do {
-                        let decoder = JSONDecoder()
-                        decoder.keyDecodingStrategy = .convertFromSnakeCase
-                        let movie = try decoder.decode(DetailMovie.self, from: data)
-                        completion(.success(movie))
+                        let movieInfo = try JSONDecoder().decode(MovieInfo.self, from: data)
+                        completion(.success(movieInfo))
                     } catch {
                         completion(.failure(error))
                     }

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/View/DetailMovie/DetailMovieView.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/View/DetailMovie/DetailMovieView.swift
@@ -9,6 +9,8 @@ import UIKit
 
 class DetailMovieView: UIView {
     
+    private var data: MovieInfo?
+    
     // MARK: - UI Properties
     
     private let posterImageView: UIImageView = {
@@ -21,34 +23,35 @@ class DetailMovieView: UIView {
     
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "title"
         label.textAlignment = .center
-        label.font = UIFont.systemFont(ofSize: 30)
-        label.heightAnchor.constraint(lessThanOrEqualToConstant: 40).isActive = true
+        label.font = UIFont.boldSystemFont(ofSize: 24)
+        label.numberOfLines = 0
         
         return label
     }()
     
     private let releaseDateLabel: UILabel = {
         let label = UILabel()
-        label.text = "releaseDate"
         label.textAlignment = .center
         label.font = UIFont.systemFont(ofSize: 16)
-        label.heightAnchor.constraint(lessThanOrEqualToConstant: 30).isActive = true
         
         return label
     }()
     
     private let discriptionLabel: UILabel = {
         let label = UILabel()
-        label.text = "discription discription discription discription discription discription discription discription discription discription discription discription discription discription discription discription discription disc"
         label.textAlignment = .center
         label.numberOfLines = 0
         
         return label
     }()
     
-    let bookNowButton: UIButton = PointButton(title: "예매하기")
+    let bookNowButton: UIButton = {
+        let button = PointButton(title: "예매하기")
+        button.contentEdgeInsets = UIEdgeInsets(top: 10, left: 0, bottom: 10, right: 0)
+
+        return button
+    }()
     
     // MARK: - Life Cycle
     
@@ -63,6 +66,16 @@ class DetailMovieView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func setData(_ data: MovieInfo) {
+        DispatchQueue.main.async {
+            let link = "https://image.tmdb.org/t/p/w500\(data.posterPath!)"
+            ImageLoader.loadImage(from: link, into: self.posterImageView)
+            
+            self.titleLabel.text = data.title
+            self.releaseDateLabel.text = "Release : \(String(describing: data.releaseDate))"
+            self.discriptionLabel.text = data.overview
+        }
+    }
 }
 
 // MARK: - Extensions
@@ -79,30 +92,56 @@ extension DetailMovieView {
         stackView.distribution = .fill
         stackView.spacing = 15
         
-        [posterImageView, titleLabel, releaseDateLabel, discriptionLabel, bookNowButton].forEach {
+        [posterImageView, titleLabel, releaseDateLabel, discriptionLabel].forEach {
             stackView.addArrangedSubview($0)
         }
         
-        self.addSubview(stackView)
-
-        setAutoLayout(stackView)
+        let descriptionScrollView = UIScrollView()
+        descriptionScrollView.addSubview(discriptionLabel)
+        stackView.addArrangedSubview(descriptionScrollView)
+        
+        [stackView, bookNowButton].forEach {
+            self.addSubview($0)
+        }
+        
+        setAutoLayout(stackView, descriptionScrollView)
     }
     
     // MARK: - Auto Layout
     
-    private func setAutoLayout(_ stackView: UIStackView) {
+    private func setAutoLayout(_ stackView: UIStackView, _ descriptionScrollView: UIScrollView) {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: self.topAnchor),
             stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
         ])
         
         posterImageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             posterImageView.heightAnchor.constraint(equalTo: stackView.heightAnchor, multiplier: 0.5)
         ])
+        
+        descriptionScrollView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            descriptionScrollView.heightAnchor.constraint(equalTo: stackView.heightAnchor, multiplier: 0.3),
+        ])
+        
+        discriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            discriptionLabel.topAnchor.constraint(equalTo: descriptionScrollView.topAnchor, constant: 15),
+            discriptionLabel.leadingAnchor.constraint(equalTo: descriptionScrollView.leadingAnchor),
+            discriptionLabel.trailingAnchor.constraint(equalTo: descriptionScrollView.trailingAnchor),
+            discriptionLabel.bottomAnchor.constraint(equalTo: descriptionScrollView.bottomAnchor),
+            discriptionLabel.widthAnchor.constraint(equalTo: descriptionScrollView.widthAnchor)
+        ])
+        
+        bookNowButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            bookNowButton.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: 15),
+            bookNowButton.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            bookNowButton.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            bookNowButton.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ])
     }
-    
 }

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/View/MovieList/MovieListCollectionView.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/View/MovieList/MovieListCollectionView.swift
@@ -7,11 +7,16 @@
 
 import UIKit
 
+protocol MovieListCollectionViewDelegate: AnyObject {
+    func didSelectMovie(withId movieId: Int)
+}
+
 class MovieListCollectionView: UIView {
     
     // MARK: - Properties
     
     var movieList: [MovieList] = []
+    weak var delegate: MovieListCollectionViewDelegate?
     
     // MARK: - UI Properties
     
@@ -40,13 +45,15 @@ class MovieListCollectionView: UIView {
         setLayout()
     }
     
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Data Update Method
+    
     func updateMovieList(_ movieList: [MovieList]) {
         self.movieList = movieList
         collectionView.reloadData()
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 }
 
@@ -86,7 +93,7 @@ extension MovieListCollectionView {
 
 // MARK: - UICollectionView
 
-extension MovieListCollectionView: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+extension MovieListCollectionView: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     
     // MARK: UICollectionViewDataSource
     
@@ -104,14 +111,16 @@ extension MovieListCollectionView: UICollectionViewDataSource, UICollectionViewD
     // MARK: UICollectionViewDelegateFlowLayout
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let cellWidth = collectionView.bounds.size.width * 0.4
+        let cellWidth = collectionView.bounds.size.width * 0.43
         let cellHeight = cellWidth * 1.6
         
         return CGSize(width: cellWidth, height: cellHeight)
     }
     
+    // MARK: UICollectionViewDelegate
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let selectedMovie = movieList[indexPath.item]
-        print(selectedMovie.id, selectedMovie.title)
+        delegate?.didSelectMovie(withId: selectedMovie.id)
     }
 }

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/DetailMovie/DetailMovieManager.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/DetailMovie/DetailMovieManager.swift
@@ -1,0 +1,21 @@
+//
+//  DetailMovieManager.swift
+//  NBCAMP-movie-team1
+//
+//  Created by t2023-m0035 on 1/18/24.
+//
+
+import UIKit
+
+class DetailMovieManager {
+    func fetchData(_ movieId: Int, completion: @escaping (DetailMovie) -> Void) {
+        DetailMovieRequest.detailMovieRequest(movieId) { result in
+            switch result {
+            case .success(let movie):
+                completion(movie)
+            case .failure(let error):
+                print("Error occurred while fetching the list: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/DetailMovie/DetailMovieManager.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/DetailMovie/DetailMovieManager.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class DetailMovieManager {
-    func fetchData(_ movieId: Int, completion: @escaping (DetailMovie) -> Void) {
+    func fetchData(_ movieId: Int, completion: @escaping (MovieInfo) -> Void) {
         DetailMovieRequest.detailMovieRequest(movieId) { result in
             switch result {
             case .success(let movie):

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/DetailMovie/DetailMovieViewController.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/DetailMovie/DetailMovieViewController.swift
@@ -9,15 +9,19 @@ import UIKit
 
 class DetailMovieViewController: UIViewController {
     
+    private let movieId: Int
+    private var data: DetailMovie?
+    private let detailMovieManager = DetailMovieManager()
+    
     // MARK: - UI Properties
     
     let detailMovieView = DetailMovieView()
-    let paymentViewController: PaymentViewController
     
     // MARK: - Life Cycle
     
-    init(paymentViewController: PaymentViewController) {
-        self.paymentViewController = paymentViewController
+    init(movieId: Int) {
+        self.movieId = movieId
+        
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -32,6 +36,8 @@ class DetailMovieViewController: UIViewController {
         
         setUI()
         setLayout()
+        
+        fetchDetailData()
     }
     
 }
@@ -40,7 +46,7 @@ class DetailMovieViewController: UIViewController {
 
 extension DetailMovieViewController {
     @objc private func goToPaymentButton() {
-        self.navigationController?.pushViewController(paymentViewController, animated: true)
+        print("결제화면으로 화면 전환")
     }
     
     private func setUI() {
@@ -58,5 +64,13 @@ extension DetailMovieViewController {
             detailMovieView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30),
             detailMovieView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -30)
         ])
+    }
+}
+
+extension DetailMovieViewController {
+    private func fetchDetailData() {
+        detailMovieManager.fetchData(movieId) { movie in
+            self.data = movie
+        }
     }
 }

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/DetailMovie/DetailMovieViewController.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/DetailMovie/DetailMovieViewController.swift
@@ -9,8 +9,10 @@ import UIKit
 
 class DetailMovieViewController: UIViewController {
     
+    // MARK: - Properties
+    
     private let movieId: Int
-    private var data: DetailMovie?
+    private var data: MovieInfo?
     private let detailMovieManager = DetailMovieManager()
     
     // MARK: - UI Properties
@@ -52,13 +54,15 @@ extension DetailMovieViewController {
     private func setUI() {
         view.backgroundColor = .white
         detailMovieView.bookNowButton.addTarget(self, action: #selector(goToPaymentButton), for: .touchUpInside)
+        
+        view.addSubview(detailMovieView)
     }
     
     private func setLayout() {
-        view.addSubview(detailMovieView)
-        
         detailMovieView.translatesAutoresizingMaskIntoConstraints = false
+        
         NSLayoutConstraint.activate([
+            
             detailMovieView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 15),
             detailMovieView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30),
             detailMovieView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30),
@@ -71,6 +75,7 @@ extension DetailMovieViewController {
     private func fetchDetailData() {
         detailMovieManager.fetchData(movieId) { movie in
             self.data = movie
+            self.detailMovieView.setData(movie)
         }
     }
 }

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/Main/MainViewController.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/Main/MainViewController.swift
@@ -12,11 +12,6 @@ class MainViewController: UIViewController {
     // MARK: - UI Properties
     
     lazy var movieListViewController = MovieListViewController()
-//    lazy var movieListViewController = MovieListViewController(detailMovieViewController: detailMovieViewController)
-//    lazy var detailMovieViewController = DetailMovieViewController(paymentViewController: paymentViewController, movieId: 0)
-//    let detailMovieView = DetailMovieView()
-//    let paymentViewController = PaymentViewController()
-//    let mypageViewController = MypageViewController()
     
     let signUserView = SignUserView()
     

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/Main/MainViewController.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/Main/MainViewController.swift
@@ -11,11 +11,12 @@ class MainViewController: UIViewController {
     
     // MARK: - UI Properties
     
-    lazy var movieListViewController = MovieListViewController(detailMovieViewController: detailMovieViewController)
-    lazy var detailMovieViewController = DetailMovieViewController(paymentViewController: paymentViewController)
-    let detailMovieView = DetailMovieView()
-    let paymentViewController = PaymentViewController()
-    let mypageViewController = MypageViewController()
+    lazy var movieListViewController = MovieListViewController()
+//    lazy var movieListViewController = MovieListViewController(detailMovieViewController: detailMovieViewController)
+//    lazy var detailMovieViewController = DetailMovieViewController(paymentViewController: paymentViewController, movieId: 0)
+//    let detailMovieView = DetailMovieView()
+//    let paymentViewController = PaymentViewController()
+//    let mypageViewController = MypageViewController()
     
     let signUserView = SignUserView()
     

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/MovieList/MovieListManager.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/MovieList/MovieListManager.swift
@@ -19,7 +19,7 @@ class MovieListManager {
                 self.movies = first10Movies
                 
                 let movieList: [MovieList] = first10Movies.map {
-                    return MovieList(title: $0.title, imagePath: $0.posterPath ?? "", id: $0.id)
+                    return MovieList(title: $0.title, imagePath: $0.posterPath!, id: $0.id)
                 }
                 
                 completion(movieList)

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/MovieList/MovieListViewController.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/MovieList/MovieListViewController.swift
@@ -17,6 +17,8 @@ class MovieListViewController: UIViewController {
     
     // MARK: - UI Properties
     
+    let searchViewController = SearchViewController()
+    
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -46,6 +48,14 @@ class MovieListViewController: UIViewController {
         return nowPlayingView
     }()
     
+    private lazy var searchButton: UIBarButtonItem = {
+        let magnifyingGlassImage = UIImage(systemName: "magnifyingglass")
+        let button = UIBarButtonItem(image: magnifyingGlassImage, style: .plain, target: self, action: #selector(goToSearchViewController))
+        button.tintColor = .systemGray
+        
+        return button
+    }()
+    
     private let movieListManager = MovieListManager()
     
     // MARK: - Life Cycle
@@ -64,18 +74,33 @@ class MovieListViewController: UIViewController {
         setUI()
         setLayout()
         setDelegate()
-    
+        setNavigationItem()
         fetchMovieListData()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        self.navigationItem.setHidesBackButton(true, animated: false)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+// MARK: - Navigation
+
+extension MovieListViewController {
+    func setNavigationItem() {
+        self.navigationItem.hidesBackButton = true
+        self.navigationItem.rightBarButtonItem = searchButton
+    }
+    
+    @objc private func goToSearchViewController() {
+        let transition = CATransition()
+        transition.type = CATransitionType.fade
+        transition.subtype = CATransitionSubtype.fromTop
+        transition.duration = 0.1
+
+        self.navigationController?.view.layer.add(transition, forKey: kCATransition)
+
+        self.navigationController?.pushViewController(searchViewController, animated: false)
     }
 }
 

--- a/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/MovieList/MovieListViewController.swift
+++ b/NBCAMP-movie-team1/NBCAMP-movie-team1/Presentation/ViewController/MovieList/MovieListViewController.swift
@@ -46,13 +46,11 @@ class MovieListViewController: UIViewController {
         return nowPlayingView
     }()
     
-    private let detailMovieViewController: DetailMovieViewController
     private let movieListManager = MovieListManager()
     
     // MARK: - Life Cycle
     
-    init(detailMovieViewController: DetailMovieViewController) {
-        self.detailMovieViewController = detailMovieViewController
+    init() {
         super.init(nibName: nil, bundle: nil)
         
         nowPlayingView.movieList = nowPlayingList
@@ -65,31 +63,9 @@ class MovieListViewController: UIViewController {
         
         setUI()
         setLayout()
+        setDelegate()
     
-        fetchDataForNowPlaying()
-    }
-    
-    func fetchDataForNowPlaying() {
-        movieListManager.fetchData("now_playing") { movieList in
-            DispatchQueue.main.async {
-                self.nowPlayingList = movieList
-                self.nowPlayingView.updateMovieList(movieList)
-            }
-        }
-        
-        movieListManager.fetchData("popular") { movieList in
-            DispatchQueue.main.async {
-                self.popularList = movieList
-                self.popularView.updateMovieList(movieList)
-            }
-        }
-        
-        movieListManager.fetchData("top_rated") { movieList in
-            DispatchQueue.main.async {
-                self.topRatedList = movieList
-                self.topRatedView.updateMovieList(movieList)
-            }
-        }
+        fetchMovieListData()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -106,10 +82,6 @@ class MovieListViewController: UIViewController {
 // MARK: - Extensions
 
 extension MovieListViewController {
-    @objc private func goToDetailMovieButton() {
-        self.navigationController?.pushViewController(detailMovieViewController, animated: true)
-    }
-    
     private func setUI() {
         view.backgroundColor = .white
         
@@ -157,5 +129,43 @@ extension MovieListViewController {
         }
         
         return stackView
+    }
+}
+
+extension MovieListViewController {
+    func fetchMovieListData() {
+        movieListManager.fetchData("now_playing") { movieList in
+            DispatchQueue.main.async {
+                self.nowPlayingList = movieList
+                self.nowPlayingView.updateMovieList(movieList)
+            }
+        }
+        
+        movieListManager.fetchData("popular") { movieList in
+            DispatchQueue.main.async {
+                self.popularList = movieList
+                self.popularView.updateMovieList(movieList)
+            }
+        }
+        
+        movieListManager.fetchData("top_rated") { movieList in
+            DispatchQueue.main.async {
+                self.topRatedList = movieList
+                self.topRatedView.updateMovieList(movieList)
+            }
+        }
+    }
+}
+
+extension MovieListViewController: MovieListCollectionViewDelegate {
+    func didSelectMovie(withId movieId: Int) {
+        let detailViewController = DetailMovieViewController(movieId: movieId)
+        navigationController?.pushViewController(detailViewController, animated: true)
+    }
+    
+    func setDelegate() {
+        nowPlayingView.delegate = self
+        popularView.delegate = self
+        topRatedView.delegate = self
     }
 }


### PR DESCRIPTION

## Feature/#19
- 영화 목록에서 영화를 선택하면 해당하는 영화의 id를 세부 화면 viewController로 보내주었습니다.
- 그 다음 세부 화면 ViewController에서 세부 내용 api 를 호출해서 데이터를 저장합니다.
- 세부에 너무 많은 정보가 있기 때문에 Decodable 데이터 형식을 좀 간결하게 바꾸었습니다.

![Jan-18-2024 15-14-49](https://github.com/NBCAMP-movie-team1/iOS/assets/107637741/df00147d-579d-411c-9127-722010ce8884)


<br/>
<br/>

## Feature/#22
- 영화 목록 화면 네비게이션 바 우측에 검색 버튼을 추가했습니다.
- 클릭 시 SearchViewController로 이동합니다.
- 화면 전환 시 애니메이션을 바꿔보고 싶어서 찾아보니 역시나 있더군요. 
    화면이 전환될 때 애니메이션을 일반적인 swipe 말고 fade로 바꿔보았습니다. 
    참고로 뒤로갈때는 똑같습니다ㅋㅋ [관련 문서 링크](https://developer.apple.com/documentation/quartzcore/catransition)

- 현재는 화면이 전환되어도 검색 상태가 유지되고 있는 것으로 보입니다. 
    그래서 영화 목록으로 이동했다가 다시 검색창으로 돌아와도 검색 된 UICollectionView가 그대로 남아있더라구요. 
    네비게이션 back 될때라던가.. 화면이 꺼질때 라던가? 검색 상태를 초기화시킨다던지, 컬렉션뷰를 초기화시켜서(아님 숨겨서..?) 사용자에게 화면을 나갔다가 돌아왔다!! 라는 느낌을 주는 것도 좋을 것 같다는 생각이 드네요! :D

![Jan-18-2024 15-13-04](https://github.com/NBCAMP-movie-team1/iOS/assets/107637741/510b5b36-ff8f-41fa-a421-3fd7b82a4147)
